### PR TITLE
HOTFIX: Disable schedule because it uses all our github data

### DIFF
--- a/.github/workflows/run_recipes.yml
+++ b/.github/workflows/run_recipes.yml
@@ -7,9 +7,10 @@ on:
   pull_request:
     branches:
       - main
-  schedule:
-    - # Run every day at 2:00 UTC
-    - cron: "0 2 * * *"
+  #schedule:
+  #  # Schedule disabled because it uses all of A*V's github data.
+  #  - # Run every day at 2:00 UTC
+  #  - cron: "0 2 * * *"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
I'll merge this today unless you object @teutoburg 

We are at 90% of our allowed storage for github action artifacts. I think this is due to the METIS_Simulations taking up too much data