### PR TITLE
Convert mjdobs from isot to mjd in updateheaders

### DIFF
--- a/ESO/updateHeaders.py
+++ b/ESO/updateHeaders.py
@@ -11,7 +11,7 @@ from importlib import reload
 import glob
 import argparse
 import os
-
+import astropy.time
 
 
 def updateHeaders(inDir,outDir):
@@ -46,7 +46,8 @@ def updateHeaders(inDir,outDir):
     for fName in fNames:
         # open the file
         hdul = fits.open(fName)
-
+        mjdobs = hdul[0].header['MJD-OBS']
+        hdul[0].header['MJD-OBS'] = astropy.time.Time(mjdobs,format="isot").mjd
         # get the tech and filter keywords
         tech = hdul[0].header['HIERARCH ESO DPR TECH']
         filt = hdul[0].header['HIERARCH ESO DRS FILTER']


### PR DESCRIPTION
EDPS was throwing errors as it expects a float MJD value in keyword "mjd-obs" but this was ISOT time. So here I added a few lines of code to do the conversion. Perhaps this should be fixed in ScopeSim instead, or more flexible in terms of parsing by not giving a format keyword?

After this update EDPS doesn't throw warnings on mjd-obs while classifying files.