### PR TITLE
Also compare the tplname in the recipes.yaml against the DRLD

### DIFF
--- a/ESO/compare_yaml_with_drld.py
+++ b/ESO/compare_yaml_with_drld.py
@@ -43,6 +43,10 @@ for name, settings in recipes.items():
     if props['type'] != di.dpr_type:
         problems.append(f"{do_catg} has DPR.TYPE {props['type']} in yaml but {di.dpr_type} in DRLD")
 
+    tplname = props["tplname"].lower()
+    if tplname not in di.templates:
+        problems.append(f"{do_catg} has tplname {tplname} but only {di.templates} create it")
+
 do_catg_used_in_yaml = {settings['prefix'] for settings in recipes.values()}
 do_catg_used_in_drld = {a for a in METIS_DataReductionLibraryDesign.dataitems if a.endswith("_RAW")}
 do_catg_only_in_yaml = do_catg_used_in_yaml - do_catg_used_in_drld


### PR DESCRIPTION
@gotten added `tplname`s to the `recipes.yaml` in #44. This adds a check whether the templates in `recipe.yaml` are consistent with the DRLD.

Currently it fails with
```
IFU_SKY_RAW has tplname metis_ifu_cal_standard but only ['metis_ifu_obs_fixedskyoffset', 'metis_ifu_obs_genericoffset', 'metis_ifu_ext_obs_fixedskyoffset', 'metis_ifu_ext_obs_genericoffset', 'metis_ifu_vc_obs_fi xedskyoffset', 'metis_ifu_ext_vc_obs_fixedskyoffset', 'metis_ifu_app_obs_stare', 'metis_ifu_ext_app_obs_stare', 'metis_ifu_cal_psf'] create it
```

We should probably update the DRLD.