### PR TITLE
add parameter --catg

### DIFF
--- a/ESO/run_recipes.py
+++ b/ESO/run_recipes.py
@@ -109,8 +109,8 @@ if __name__ == "__main__":
 
     small = args.small
 
-    if args.procatg:
-        catglist = args.procatg.split(',')
+    if args.catg:
+        catglist = args.catg.split(',')
     else:
         catglist = None
 


### PR DESCRIPTION
New parameter `--procatg` (`-p`) allows to specify a comma-separated list of file categories that the script shall produce, e.g.
```run_recipes.py -p DARK_2RG_RAW,DARK_GEO_RAW```
An error is raised if any of specified categories do not exist in the yaml file.

Short versions of the arguments have been added (`-i`, `-o`, `-s`, `-p`).

Downloading of the instrument packages is deferred until after argument parsing and checking. This necessitated putting the import from `raw_script` into the `run()` function, which is a bit dodgy.