### PR TITLE
Fix units for new ScopeSim_Templates

### DIFF
--- a/ESO/raw_script.py
+++ b/ESO/raw_script.py
@@ -52,10 +52,10 @@ def simulate(fname, mode, kwargs, source=None, small=False):
         src_kwargs |= source["kwargs"]
 
     # Fix units
-    if 'temperature' in src_kwargs:
-        src_kwargs['temperature'] <<= u.K
-    if 'amplitude' in src_kwargs:
-        src_kwargs['amplitude'] <<= u.ABmag
+    if "temperature" in src_kwargs and not isinstance(src_kwargs["temperature"], u.Quantity):
+        src_kwargs["temperature"] <<= u.K
+    if "amplitude" in src_kwargs and not isinstance(src_kwargs["amplitude"], u.Quantity):
+        src_kwargs["amplitude"] <<= u.ABmag
 
     src = src_fct(**src_kwargs)
     logger.info("Source function: %s", src_fct.__name__)

--- a/ESO/raw_script.py
+++ b/ESO/raw_script.py
@@ -51,6 +51,12 @@ def simulate(fname, mode, kwargs, source=None, small=False):
     if isinstance(source, Mapping):
         src_kwargs |= source["kwargs"]
 
+    # Fix units
+    if 'temperature' in src_kwargs:
+        src_kwargs['temperature'] <<= u.K
+    if 'amplitude' in src_kwargs:
+        src_kwargs['amplitude'] <<= u.ABmag
+
     src = src_fct(**src_kwargs)
     logger.info("Source function: %s", src_fct.__name__)
     logger.debug("Source kwargs: %s", src_kwargs)


### PR DESCRIPTION
Newer versions of ScopeSim_Templates require some units to be explicitly set.

Not sure whether this also works for the earlier versions of ScopeSim_Templates though. So marking as draft until we can actually upgrade to the latest ScopeSim_Templates