### PR TITLE
Check SOF files for missing RAWs

### DIFF
--- a/ESO/check_sof_files.py
+++ b/ESO/check_sof_files.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+from pathlib import Path
+
+PATH_HERE = Path(__file__).parent
+PATH_SOFS = PATH_HERE / "sofFiles"
+PATH_FITS = PATH_HERE / "output"
+
+for filename in PATH_SOFS.glob("*.sof"):
+    # print(filename)
+    lines = open(filename, mode="r", encoding="utf-8").readlines()
+    fns_raw = [
+        line.split()[0].split("/")[1]
+        for line in lines
+        if "RAW" in line
+    ]
+    fns_raw_missing = [
+        fn
+        for fn in fns_raw
+        if not (PATH_FITS / fn).exists()
+    ]
+    if fns_raw_missing:
+        print(filename)
+        print(fns_raw_missing)
+

--- a/ESO/check_sof_files.py
+++ b/ESO/check_sof_files.py
@@ -6,6 +6,8 @@ PATH_HERE = Path(__file__).parent
 PATH_SOFS = PATH_HERE / "sofFiles"
 PATH_FITS = PATH_HERE / "output"
 
+problems = []
+
 for filename in PATH_SOFS.glob("*.sof"):
     # print(filename)
     lines = open(filename, mode="r", encoding="utf-8").readlines()
@@ -20,6 +22,12 @@ for filename in PATH_SOFS.glob("*.sof"):
         if not (PATH_FITS / fn).exists()
     ]
     if fns_raw_missing:
-        print(filename)
-        print(fns_raw_missing)
+        problems.append((filename.name, fns_raw_missing))
 
+if problems:
+    print("Some RAW files are missing:")
+    for fn_sof, fns_missing in problems:
+        print("-", fn_sof)
+        for fn in fns_missing:
+            print("  -", fn)
+    exit(1)


### PR DESCRIPTION
The `check_sof_files.py` script checks whether all RAW files mentioned in the SOF files actually exist.

It currently detects some missing `WCU_OFF_RAW` files; it outputs

```
Some RAW files are missing:
- metis_ifu_dark.sof
  - METIS.DARK_IFU_RAW.2024-01-02_00_50_04.fits
- metis_lm_adc_slitloss.sof
  - METIS.LM_WCU_OFF_RAW.2024-01-02_00_50_27.fits
- metis_lm_img_distortion.sof
  - METIS.LM_WCU_OFF_RAW.2024-01-02_00_50_27.fits
- metis_lm_lingain.sof
  - METIS.LM_WCU_OFF_RAW.2024-01-02_00_50_27.fits
- metis_n_adc_slitloss.sof
  - METIS.N_WCU_OFF_RAW.2024-01-02_00_50_32.fits
- metis_n_img_distortion.sof
  - METIS.N_WCU_OFF_RAW.2024-01-02_00_50_32.fits
- metis_n_lingain.sof
  - METIS.N_WCU_OFF_RAW.2024-01-02_00_50_32.fits
```

There are some similarly named files in the output directory, but I did not investigate further.

@JenniferKarr, should these files exist?

