### PR TITLE
Add a dot in REF_STD_CAT, REF_STD_CAT_star1 -> REF_STD_CAT.star1

### DIFF
--- a/Simulations/python/makeCalibPrototypes.py
+++ b/Simulations/python/makeCalibPrototypes.py
@@ -38,7 +38,7 @@ def generateStaticCalibs(outputDir):
     generated (once, or on the fly as appropriate) by dedicated recipes, but 
     protoyping the format is a necessary first step.
     """
-    
+
     #################### REF_STD_CAT ###################
 
     # Generate a FITS file for a calibration spectrum. FITS file contains
@@ -64,7 +64,7 @@ def generateStaticCalibs(outputDir):
 
 
     hdul = fits.HDUList([primaryhdu, hdu])
-    hdul.writeto(f"{outputDir}/REF_STD_CAT_{starName}.fits",overwrite=True)
+    hdul.writeto(f"{outputDir}/REF_STD_CAT.{starName}.fits",overwrite=True)
 
     #################### FLUXSTD_CATALOG ###################
 


### PR DESCRIPTION
Add a dot in REF_STD_CAT, REF_STD_CAT_star1 -> REF_STD_CAT.star1.

The `check_headers.py` script relies on that the CATG is separated by periods.