### PR TITLE
Run the CI at least every week

### DIFF
--- a/.github/workflows/run_recipes.yml
+++ b/.github/workflows/run_recipes.yml
@@ -7,10 +7,11 @@ on:
   pull_request:
     branches:
       - main
-  #schedule:
-  #  # Schedule disabled because it uses all of A*V's github data.
-  #  - # Run every day at 2:00 UTC
-  #  - cron: "0 2 * * *"
+  schedule:
+    # Run every Sunday at 1:05 UTC.
+    # We can't run this more often because otherwise it might use all
+    # of A*V's github data.
+    - cron: "5 1 * * 7"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The CI currently fails, and we didn't notice, because it doesn't run automatically. Let's restart that.