### PR TITLE
Make sure nothing breaks if dit is a list

### DIFF
--- a/Simulations/python/setupSimulations.py
+++ b/Simulations/python/setupSimulations.py
@@ -201,12 +201,17 @@ class setupSimulations():
         """
 
         self.tObs = self.tObs + self.tDelt
-        self.tDelt =  TimeDelta(float(recipe['properties']['dit'])*recipe['properties']['ndit']*1.2+1, format='sec')
+        dit = recipe["properties"]['dit']
+        if isinstance(dit, (list, tuple)):
+            assert len(dit) == 1, f"{dit=} is a list"
+            dit = dit[0]
+
+        self.tDelt =  TimeDelta(float(dit)*recipe['properties']['ndit']*1.2+1, format='sec')
         recipe["properties"]["dateobs"] = self.tObs.tt.datetime
         recipe["properties"]["MJD-OBS"] = self.tObs.mjd
         recipe["properties"]["tplexpno"] = self.tplExpno
 
-        self.fname = self.outDir / self.generateFilename(recipe["properties"]['dateobs'],recipe['mode'],recipe["properties"]['dit'],recipe["do.catg"])
+        self.fname = self.outDir / self.generateFilename(recipe["properties"]['dateobs'],recipe['mode'],dit,recipe["do.catg"])
         self.tplExpno += 1
 
         return recipe


### PR DESCRIPTION
`dit` is a list in several entries in the yaml files. E.g. in `imgLM.yaml`:
```yaml
DETLIN_2RG_RAW:
  do.catg: DETLIN_2RG_RAW
  mode: "wcu_img_lm"
  source:
    name: empty_sky
    kwargs: {}
  properties:
    dit:
      - 1.
    ndit: 1
```

This breaks `run_recipes.py`:
```
python3 -i python/run_recipes.py --inputYAML=YAML/imgLM.yaml --nCores=1
Recipes loaded from YAML/imgLM.yaml
No appropriate starting time found; setting to default value
{'do.catg': 'DETLIN_2RG_RAW', 'mode': 'wcu_img_lm', 'source': {'name': 'empty_sky', 'kwargs': {}}, 'properties': {'dit': [1.0], 'ndit': 1, 'filter_name': 'open', 'catg': 'CALIB', 'tech': 'IMAGE,LM', 'type': 'DETLIN', 'tplname': 'METIS_img_lm_cal_DetLin', 'nObs': 1}, 'wcu': {'current_lamp': 'bb', 'current_fpmask': 'open', 'bb_aperture': 0.5, 'bb_temp': 800, 'is_temp': 300, 'wcu_temp': 300}}
Traceback (most recent call last):
  File "[..]/METIS_Simulations/Simulations/python/run_recipes.py", line 48, in <module>
    runRecipes(sys.argv)
  File "[..]/METIS_Simulations/Simulations/python/run_recipes.py", line 32, in runRecipes
    simulationSet.runSimulations()
  File "[..]/METIS_Simulations/Simulations/python/setupSimulations.py", line 190, in runSimulations
    self._run(self.allrcps)
  File "[..]/METIS_Simulations/Simulations/python/setupSimulations.py", line 354, in _run
    recipe = self.increment(recipe)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "[..]/METIS_Simulations/Simulations/python/setupSimulations.py", line 204, in increment
    self.tDelt =  TimeDelta(float(recipe['properties']['dit'])*recipe['properties']['ndit']*1.2+1, format='sec')
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: float() argument must be a string or a real number, not 'list'
```
The list always contains only 1 element though, so this patch would at least allow the code to run.