### PR TITLE
Make dits that are a list not a list

### DIFF
--- a/Simulations/YAML/allRecipes.yaml
+++ b/Simulations/YAML/allRecipes.yaml
@@ -58,8 +58,7 @@ DETLIN_2RG_RAW:
     name: empty_sky
     kwargs: {}
   properties:
-    dit:
-      - 1.
+    dit: 1.
     ndit: 1
     filter_name: "open"
     catg: "CALIB"
@@ -193,8 +192,7 @@ DETLIN_GEO_RAW:
     name: empty_sky
     kwargs: {}
   properties:
-    dit:
-      - 1.
+    dit: 1.
     ndit: 1
     filter_name: "open"
     catg: "CALIB"
@@ -378,8 +376,7 @@ DETLIN_2RG_RAW:
     name: empty_sky
     kwargs: {}
   properties:
-    dit:
-      - 1.
+    dit: 1.
     ndit: 1
     filter_name: "open"
     catg: "CALIB"
@@ -551,8 +548,7 @@ DETLIN_GEO_RAW:
     name: empty_sky
     kwargs: {}
   properties:
-    dit:
-      - 1.
+    dit: 1.
     ndit: 1
     filter_name: "open"
     catg: "CALIB"
@@ -679,8 +675,7 @@ DETLIN_IFU_RAW:
     name: empty_sky
     kwargs: {}
   properties:
-    dit:
-      - 1.
+    dit: 1.
     ndit: 1
     filter_name: "open"
     catg: "CALIB"

--- a/Simulations/YAML/ifu.yaml
+++ b/Simulations/YAML/ifu.yaml
@@ -11,8 +11,7 @@ DETLIN_IFU_RAW:
     name: empty_sky
     kwargs: {}
   properties:
-    dit:
-      - 1.
+    dit: 1.
     ndit: 1
     filter_name: "open"
     catg: "CALIB"

--- a/Simulations/YAML/imgLM.yaml
+++ b/Simulations/YAML/imgLM.yaml
@@ -11,8 +11,7 @@ DETLIN_2RG_RAW:
     name: empty_sky
     kwargs: {}
   properties:
-    dit:
-      - 1.
+    dit: 1.
     ndit: 1
     filter_name: "open"
     catg: "CALIB"

--- a/Simulations/YAML/imgN.yaml
+++ b/Simulations/YAML/imgN.yaml
@@ -11,8 +11,7 @@ DETLIN_GEO_RAW:
     name: empty_sky
     kwargs: {}
   properties:
-    dit:
-      - 1.
+    dit: 1.
     ndit: 1
     filter_name: "open"
     catg: "CALIB"

--- a/Simulations/YAML/lssLM.yaml
+++ b/Simulations/YAML/lssLM.yaml
@@ -60,8 +60,7 @@ DETLIN_2RG_RAW:
     name: empty_sky
     kwargs: {}
   properties:
-    dit:
-      - 1.
+    dit: 1.
     ndit: 1
     filter_name: "open"
     catg: "CALIB"

--- a/Simulations/YAML/lssN.yaml
+++ b/Simulations/YAML/lssN.yaml
@@ -58,8 +58,7 @@ DETLIN_GEO_RAW:
     name: empty_sky
     kwargs: {}
   properties:
-    dit:
-      - 1.
+    dit: 1.
     ndit: 1
     filter_name: "open"
     catg: "CALIB"

--- a/Simulations/YAML/wcu.yaml
+++ b/Simulations/YAML/wcu.yaml
@@ -16,8 +16,7 @@ DETLIN_2RG_RAW:
       filter_curve: "V"
       extend: 15
   properties:
-    dit:
-      - 1.
+    dit: 1.
     ndit: 1
     filter_name: "open"
     catg: "CALIB"
@@ -37,8 +36,7 @@ DETLIN_GEO_RAW:
       filter_curve: "V"
       extend: 15
   properties:
-    dit:
-      - 1.
+    dit: 1.
     ndit: 1
     filter_name: "open"
     catg: "CALIB"
@@ -58,8 +56,7 @@ DETLIN_IFU_RAW:
       filter_curve: "V"
       extend: 15
   properties:
-    dit:
-      - 1.
+    dit: 1.
     ndit: 1
     filter_name: "open"
     catg: "CALIB"


### PR DESCRIPTION
It seems that having a list for dit values is not supported anymore. Most dits in the YAML files are just floats, but some are still lists. If they are a, it is always a list of one item, so this changes those entries to not-lists.

This is a better solution to the problem than #121, so this supersedes that.