### PR TITLE
Do not upload large artifacts in the dail build.

### DIFF
--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -35,9 +35,3 @@ jobs:
           cd Simulations
           python3.12 python/downloadPackages.py
           ./runESO.sh
-
-      - name: Store output files
-        uses: actions/upload-artifact@v4
-        with:
-          name: output
-          path: output/


### PR DESCRIPTION
 This will quickly fill our allocated storage. And it is very difficult to reduce the used storage without paying.