### PR TITLE
Fix N_SYNTH_TRANS PRO.CATG value

### DIFF
--- a/Simulations/python/makeCalibPrototypes.py
+++ b/Simulations/python/makeCalibPrototypes.py
@@ -124,7 +124,7 @@ def generateStaticCalibs(outputDir):
     ld = fits.Column(name='wavelength', array=np.arange(0,100), format='E')
     trans = fits.Column(name='transmission', array=np.ones(100), format='E')
     primaryhdu = fits.PrimaryHDU()
-    primaryhdu.header['HIERARCH ESO PRO CATG'] = " N_SYNTH_TRANS"
+    primaryhdu.header['HIERARCH ESO PRO CATG'] = "N_SYNTH_TRANS"
     primaryhdu.header['INSTRUME'] = "METIS"
 
     hdu = fits.BinTableHDU.from_columns([ld, trans])


### PR DESCRIPTION
Remove space in PRO.CATG value of N_SYNTH_TRANS static calibration.

Not sure whether @JenniferKarr is back already, so also assigning @janusbrink .