### PR TITLE
Max cores

### DIFF
--- a/Simulations/python/runRecipes.py
+++ b/Simulations/python/runRecipes.py
@@ -745,7 +745,7 @@ class runRecipes():
         
         if(not self.params['testRun']):
             # Always keep one core free.
-            nCores = min(self.params['nCores'], cpu_count() - 1)
+            nCores = max(min(self.params['nCores'], cpu_count() - 1), 1)
 
             with Pool(nCores) as pool:
                 pool.starmap(simulate, allArgs)

--- a/Simulations/python/setupSimulations.py
+++ b/Simulations/python/setupSimulations.py
@@ -265,7 +265,7 @@ class setupSimulations():
                 simulate(self.fname, recipe, small=self.params['small'])
         # now actually run
         #if(not self.params['testRun']):
-        #    nCores = self.params['nCores']
+        #    nCores = max(min(self.params['nCores'], cpu_count() - 1), 1)
         #
         #    with Pool(nCores) as pool:
         #        pool.starmap(simulate, allArgs)
@@ -308,7 +308,7 @@ class setupSimulations():
         # now actually run
         if(not self.params['testRun']):
             # Always keep one core free.
-            nCores = min(self.params['nCores'], cpu_count() - 1)
+            nCores = max(min(self.params['nCores'], cpu_count() - 1), 1)
         
             with Pool(nCores) as pool:
                 pool.starmap(simulate, allArgs)
@@ -395,7 +395,8 @@ class setupSimulations():
 
         # now actually run
         if(not self.params['testRun']):
-            nCores = self.params['nCores']
+            # Always keep one core free.
+            nCores = max(min(self.params['nCores'], cpu_count() - 1), 1)
         
             with Pool(nCores) as pool:
                 pool.starmap(simulate, allArgs)


### PR DESCRIPTION
Always keep one CPU core free, unless there is only one core. So only use 8 cores if there are at least 9 cores available.

Reason: ifu.py seems to dead lock on my machine with only 4 cores. It creates 12 files then just hangs waiting for something.