### PR TITLE
Fix floating point ndit values

### DIFF
--- a/Simulations/YAML/testYAML.yaml
+++ b/Simulations/YAML/testYAML.yaml
@@ -611,7 +611,7 @@ IFU_WCU_OFF_RAW:
         tplname: "METIS_lms_det_dark"
         nObs: 1
         dit: 1.
-        ndit: 1.
+        ndit: 1
   wcu:
         current_lamp: "bb"
         current_fpmask: "open"
@@ -637,7 +637,7 @@ LM_WCU_OFF_RAW:
         tplname: "METIS_lm_det_dark"
         nObs: 1
         dit: 1.
-        ndit: 1.
+        ndit: 1
   wcu:
         current_lamp: "bb"
         current_fpmask: "open"
@@ -663,7 +663,7 @@ N_WCU_OFF_RAW:
         tplname: "METIS_n_det_dark"
         nObs: 1
         dit: 1.
-        ndit: 1.
+        ndit: 1
   wcu:
         current_lamp: "bb"
         current_fpmask: "open"


### PR DESCRIPTION
There were some floating point NDIT values in testYAML.yaml, which breaks when ingesting them into the database. (These are only for testing though, but still good to have them functional.)