### PR TITLE
Fix flatlamp DPR.TECH keyword

### DIFF
--- a/Simulations/YAML/flatLampLM.yaml
+++ b/Simulations/YAML/flatLampLM.yaml
@@ -8,7 +8,7 @@ WCU_FLAT_LM_RAW:
     filter_name: "open"
     ndfilter_name: "open"
     catg: "CALIB"
-    tech: "LM"
+    tech: "IMAGE,LM"
     type: "FLAT,LAMP"
     tplname: "METIS_img_lm_det_flat"
     dit: 1

--- a/Simulations/YAML/flatLampN.yaml
+++ b/Simulations/YAML/flatLampN.yaml
@@ -8,7 +8,7 @@ WCU_FLAT_N_RAW:
     filter_name: "open"
     ndfilter_name: "open"
     catg: "CALIB"
-    tech: "N"
+    tech: "IMAGE,N"
     type: "FLAT,LAMP"
     tplname: "METIS_img_n_det_flat"
     dit: 1

--- a/Simulations/YAML/testYAML.yaml
+++ b/Simulations/YAML/testYAML.yaml
@@ -176,7 +176,7 @@ WCU_FLAT_LM_RAW:
     filter_name: "open"
     ndfilter_name: "open"
     catg: "CALIB"
-    tech: "LM"
+    tech: "IMAGE,LM"
     type: "FLAT,LAMP"
     tplname: "METIS_img_lm_det_flat"
     dit: 1
@@ -200,7 +200,7 @@ WCU_FLAT_N_RAW:
     filter_name: "open"
     ndfilter_name: "open"
     catg: "CALIB"
-    tech: "N"
+    tech: "IMAGE,N"
     type: "FLAT,LAMP"
     tplname: "METIS_img_n_det_flat"
     dit: 1


### PR DESCRIPTION
Some flats have the wrong `DPR.TECH` keyword, namely just `LM` or `N`, while it should be `IMAGE,LM` and `IMAGE,N`