### PR TITLE
Add slit_name parameter to LSS simulations

### DIFF
--- a/AIT_Tests/LMS_RAD_06/LMS_RAD_06.yaml
+++ b/AIT_Tests/LMS_RAD_06/LMS_RAD_06.yaml
@@ -1,0 +1,502 @@
+
+############ DETLIN WITH DIFFERENT EXPOSURE TIMES ##################
+
+DETLIN_IFU_RAW1:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.3
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW2:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 2
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW3:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 3.
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW4:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 4
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW5:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 5
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW6:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 6
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW7:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 7
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW8:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 8
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW9:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 9
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW10:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 10
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW11:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 11
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW12:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 12
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW13:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 13
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW14:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 14
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW15:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 15
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW16:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 16
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW17:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 17
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW18:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 18
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW19:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 19
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW20:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 20
+    ndit: 4
+    wavelen: 5.2
+    filter_name: "open"
+    ndfilter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 2
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 1000
+    is_temp: 300
+    wcu_temp: 300

--- a/AIT_Tests/LSS_RAD_03/LSS_RAD_03_lm.yaml
+++ b/AIT_Tests/LSS_RAD_03/LSS_RAD_03_lm.yaml
@@ -1,0 +1,104 @@
+LM_LSS_SCI_SKY_RAW_L:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_l"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 100
+    ndit: 120
+    filter_name: "L_spec"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 2
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+LM_LSS_SCI_SKY_RAW_M:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_m"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 100
+    ndit: 120
+    filter_name: "M_spec"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 2
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+
+LM_LSS_SCI_SKY_RAW_L_ND:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_l"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 100
+    ndit: 120
+    filter_name: "L_spec"
+    ndfilter_name: "ND_OD4"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 2
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+LM_LSS_SCI_SKY_RAW_M_ND:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_m"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 100
+    ndit: 120
+    filter_name: "M_spec"
+    ndfilter_name: "ND_OD4"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 2
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300

--- a/AIT_Tests/LSS_RAD_03/LSS_RAD_03_n.yaml
+++ b/AIT_Tests/LSS_RAD_03/LSS_RAD_03_n.yaml
@@ -1,0 +1,51 @@
+LM_LSS_SCI_SKY_RAW_N:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.1
+    ndit: 120
+    filter_name: "N-spec"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 2
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+LM_LSS_SCI_SKY_RAW_N:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.1
+    ndit: 120
+    filter_name: "N-spec"
+    ndfilter_name: "ND_OD3"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 2
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300

--- a/AIT_Tests/LSS_RAD_04/LSS_RAD_04_lm.yaml
+++ b/AIT_Tests/LSS_RAD_04/LSS_RAD_04_lm.yaml
@@ -1,0 +1,26 @@
+LM_LSS_SCI_SKY_RAW:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_l"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 20
+    ndit: 4
+    filter_name: "L_spec"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 2
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 750
+    is_temp: 300
+    wcu_temp: 300

--- a/AIT_Tests/LSS_RAD_04/LSS_RAD_04_n.yaml
+++ b/AIT_Tests/LSS_RAD_04/LSS_RAD_04_n.yaml
@@ -1,0 +1,27 @@
+N_LSS_SCI_SKY_RAW:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.1
+    ndit: 800
+    filter_name: "N-spec"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 2
+    nObs: 2
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: high_capacaty
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 750
+    is_temp: 300
+    wcu_temp: 300

--- a/AIT_Tests/LSS_RAD_12/LSS_RAD_12_lm.yaml
+++ b/AIT_Tests/LSS_RAD_12/LSS_RAD_12_lm.yaml
@@ -1,0 +1,404 @@
+L_LSS_SCI_SKY_RAW_1:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_l"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "L_spec"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+L_LSS_SCI_SKY_RAW_2:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_l"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "Lp"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+L_LSS_SCI_SKY_RAW_3:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_l"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "short-L"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+L_LSS_SCI_SKY_RAW_4:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_l"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "Br_alpha"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+L_LSS_SCI_SKY_RAW_5:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_l"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "Br_alpha_ref"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+L_LSS_SCI_SKY_RAW_6:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_l"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "PAH_3.3"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+L_LSS_SCI_SKY_RAW_7:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_l"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "PAH_3.3_ref"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+L_LSS_SCI_SKY_RAW_8:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_l"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "H2O-ice"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+L_LSS_SCI_SKY_RAW_9:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_l"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "IB_4.05"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+L_LSS_SCI_SKY_RAW_10:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_l"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "HCI_L_short"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+L_LSS_SCI_SKY_RAW_11:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_l"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "HCI_L_long"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+M_LSS_SCI_SKY_RAW_1:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_m"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "M_spec"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+M_LSS_SCI_SKY_RAW_2:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_m"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "Mp"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+M_LSS_SCI_SKY_RAW_3:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_m"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "CO_1-0_ice"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+M_LSS_SCI_SKY_RAW_4:
+  do.catg: LM_LSS_SKY_RAW
+  mode: "wcu_lss_m"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 160
+    filter_name: "CO_ref"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,LM"
+    type: "SKY"
+    tplname: "METIS_spec_lm_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 0.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: fast
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300

--- a/AIT_Tests/LSS_RAD_12/LSS_RAD_12_n.yaml
+++ b/AIT_Tests/LSS_RAD_12/LSS_RAD_12_n.yaml
@@ -1,0 +1,323 @@
+N_LSS_SCI_SKY_RAW_1:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 400
+    filter_name: "N_spec"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: hight_capacaty
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+N_LSS_SCI_SKY_RAW_2:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 400
+    filter_name: "N1"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: hight_capacaty
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+N_LSS_SCI_SKY_RAW_3:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 400
+    filter_name: "N2"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: hight_capacaty
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+N_LSS_SCI_SKY_RAW_4:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 400
+    filter_name: "N3"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: hight_capacaty
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+N_LSS_SCI_SKY_RAW_5:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 400
+    filter_name: "PAH_8.6"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: hight_capacaty
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+N_LSS_SCI_SKY_RAW_6:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 400
+    filter_name: "PAH_8.6_ref"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: hight_capacaty
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+N_LSS_SCI_SKY_RAW_7:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 400
+    filter_name: "PAH_11.25"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: hight_capacaty
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+N_LSS_SCI_SKY_RAW_8:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 400
+    filter_name: "PAH_11.25_ref"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: hight_capacaty
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+N_LSS_SCI_SKY_RAW_9:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 400
+    filter_name: "Ne_II"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: hight_capacaty
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+N_LSS_SCI_SKY_RAW_10:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 400
+    filter_name: "Ne_II_ref"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: hight_capacaty
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+N_LSS_SCI_SKY_RAW_11:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 400
+    filter_name: "S_IV"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: hight_capacaty
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+N_LSS_SCI_SKY_RAW_12:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 400
+    filter_name: "S_IV_ref"
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: hight_capacaty
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300

--- a/AIT_Tests/LSS_RAD_12/LSS_RAD_12_n_list.yaml
+++ b/AIT_Tests/LSS_RAD_12/LSS_RAD_12_n_list.yaml
@@ -1,0 +1,26 @@
+N_LSS_SCI_SKY_RAW_1:
+  do.catg: N_LSS_SKY_RAW
+  mode: "wcu_lss_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 400
+    filter_name: ['N_spec', 'PAH_8.6']
+    ndfilter_name: "open"
+    catg: "SCIENCE"
+    tech: "LSS,N"
+    type: "SKY"
+    tplname: "METIS_spec_n_obs_AutoNodOnSlit"
+    nObs: 1
+    pupil_transmission: 1.0
+    slit_name: 'A-19_0'
+    detector_readout_mode: 'high_capacity'
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 1.0
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300

--- a/Simulations/YAML/scienceIFU.yaml
+++ b/Simulations/YAML/scienceIFU.yaml
@@ -15,6 +15,7 @@ IFU_SCI_RAW:
     type: "OBJECT"
     tplname: "METIS_ifu_obs_GenericOffset"
     nObs: 1
+    pupil_transmission: 0.0 
 
 IFU_SCI_SKY_RAW:
   do.catg: IFU_SKY_RAW

--- a/Simulations/python/ifu.py
+++ b/Simulations/python/ifu.py
@@ -8,7 +8,7 @@ import runSimulationBlock as rsb
 
 if __name__ == "__main__":
     params = {}
-    params['outputDir'] = "output/ifu"
+    params['outputDir'] = "output/ifu_new"
     params['small'] = False
     params['doStatic'] = True
     params['doCalib'] = 2
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     params['nCores'] = 6
     params['testRun'] = False
 
-    yamlFiles = ["YAML/wavecalIFU.yaml","YAML/scienceIFU.yaml","YAML/stdIFU.yaml","YAML/detlinIFU.yaml","YAML/distortionIFU.yaml","YAML/rsrfIFU.yaml","YAML/rsrfPinhIFU.yaml"]
+    yamlFiles = ["YAML/scienceIFU.yaml"]
 
     rsb.runSimulationBlock(yamlFiles,params)
 

--- a/Simulations/python/lssLM.py
+++ b/Simulations/python/lssLM.py
@@ -17,6 +17,7 @@ if __name__ == "__main__":
     params['calibFile'] = None
     params['nCores'] = 8
     params['testRun'] = False
+    params['slit_name'] = "C-38_1"
 
     yamlFiles = ["YAML/scienceLSSLM.yaml","YAML/stdLSSLM.yaml","YAML/detlinLM.yaml","YAML/distortionLM.yaml","YAML/rsrfLSSLM.yaml","YAML/rsrfPinhLSSLM.yaml","YAML/wavecalLSSLM.yaml","YAML/slitlossLSSLM.yaml"]
 

--- a/Simulations/python/lssN.py
+++ b/Simulations/python/lssN.py
@@ -17,6 +17,7 @@ if __name__ == "__main__":
     params['calibFile'] = None
     params['nCores'] = 8
     params['testRun'] = False
+    params['slit_name'] = "D-57_1"
 
     yamlFiles = ["YAML/scienceLSSN.yaml","YAML/stdLSSN.yaml","YAML/detlinN.yaml","YAML/distortionN.yaml","YAML/rsrfLSSN.yaml","YAML/rsrfPinhLSSN.yaml","YAML/wavecalLSSN.yaml","YAML/slitlossLSSN.yaml"]
 

--- a/Simulations/python/lssN.py
+++ b/Simulations/python/lssN.py
@@ -8,18 +8,17 @@ import runSimulationBlock as rsb
 
 if __name__ == "__main__":
     params = {}
-    params['outputDir'] = "output/lssN"
+    params['outputDir'] = "../AIT_Tests/LSS_RAD_12"
     params['small'] = False
-    params['doStatic'] = True
+    params['doStatic'] = False
     params['doCalib'] = 2
     params['sequence'] = True
     params['startMJD'] =  "2027-01-28 00:00:00"
     params['calibFile'] = None
-    params['nCores'] = 8
+    params['nCores'] = 6
     params['testRun'] = False
-    params['slit_name'] = "D-57_1"
 
-    yamlFiles = ["YAML/scienceLSSN.yaml","YAML/stdLSSN.yaml","YAML/detlinN.yaml","YAML/distortionN.yaml","YAML/rsrfLSSN.yaml","YAML/rsrfPinhLSSN.yaml","YAML/wavecalLSSN.yaml","YAML/slitlossLSSN.yaml"]
+    yamlFiles = ["../AIT_Tests/LSS_RAD_12/LSS_RAD_12_n_list.yaml"]
 
     rsb.runSimulationBlock(yamlFiles,params)
 

--- a/Simulations/python/runRecipes.py
+++ b/Simulations/python/runRecipes.py
@@ -392,13 +392,13 @@ class runRecipes():
         ii=0
         for name, recipe in self.dorcps.items():
             expanded = [key for key in sd.expandables
-                        if isinstance(recipe["properties"][key], list)]
+                        if isinstance(recipe["properties"].get(key), list)]
             combos = product(*[recipe["properties"][key] for key in expanded])
 
             for combo in combos:
                 combodict = dict(zip(expanded, combo))
                 props = recipe["properties"] | combodict
-                
+
                 try:
                     nfname = props["ndfilter_name"]
                 except:
@@ -644,7 +644,7 @@ class runRecipes():
             # expand the expandables
 
             expanded = [key for key in sd.expandables
-                        if isinstance(recipe["properties"][key], list)]
+                        if isinstance(recipe["properties"].get(key), list)]
             combos = product(*[recipe["properties"][key] for key in expanded])
     
             # get the mode and the prefix for the title

--- a/Simulations/python/scopesimWrapper.py
+++ b/Simulations/python/scopesimWrapper.py
@@ -104,6 +104,8 @@ def simulate(fname, rcp, small=False):
         cmd["!OBS.tplexpno"] = props["tplexpno"]
     if("tplstart" in props.keys()):
         cmd["!OBS.tplstart"] = props["tplstart"]
+    if "slit_name" in props:
+        cmd["!OBS.slit"] = props["slit_name"]
 
     # set up the optical train
 

--- a/Simulations/python/scopesimWrapper.py
+++ b/Simulations/python/scopesimWrapper.py
@@ -106,6 +106,10 @@ def simulate(fname, rcp, small=False):
         cmd["!OBS.tplstart"] = props["tplstart"]
     if "slit_name" in props:
         cmd["!OBS.slit"] = props["slit_name"]
+    if "pupil_transmission" in props:
+        cmd["!OBS.pupil_transmission"] = props["pupil_transmission"]
+    if 'detector_readout_mode' in props:
+        cmd["!OBS.detector_readout_mode"] = props['detector_readout_mode']
 
     # set up the optical train
 

--- a/Simulations/python/scopesimWrapper.py
+++ b/Simulations/python/scopesimWrapper.py
@@ -89,8 +89,7 @@ def simulate(fname, rcp, small=False):
     cmd["!OBS.tech"] = props["tech"]
     cmd["!OBS.mjd-obs"] = props["MJD-OBS"]
     cmd["!OBS.dateobs"] = props["dateobs"]
-    # TODO: Ensure ndfilter_name is always defined.
-    cmd["!OBS.nd_filter_name"] = props.get("ndfilter_name", "open")
+    cmd["!OBS.nd_filter_name"] = props.get("ndfilter_name") or "open"
     cmd["!OBS.filter_name"] = props["filter_name"]
     if cmd["!OBS.filter_name"] == "closed":
         cmd["!OBS.filter_name"] = "open"

--- a/Simulations/python/setupSimulations.py
+++ b/Simulations/python/setupSimulations.py
@@ -349,7 +349,11 @@ class setupSimulations():
             self.tplExpno = 0
             
             props = recipe["properties"]
-            
+
+            # Apply global slit_name default if not set per-recipe
+            if 'slit_name' not in props and 'slit_name' in self.params:
+                props['slit_name'] = self.params['slit_name']
+
             recipe["properties"]["tplstart"] = self.tplStart
 
             # for nObs exposures of each set of parameters
@@ -507,12 +511,12 @@ class setupSimulations():
             
             if(tech == "LSS,LM"):
                 hdul[0].header['HIERARCH ESO INS MODE'] = "SPEC_LM"
-                #hdul[0].header['HIERARCH ESO INS OPTI9 NAME'] = filt
-                #hdul[0].header['HIERARCH ESO INS DRS SLIT'] = "C-38_1"
+                if 'HIERARCH ESO INS OPTI3 NAME' in hdul[0].header:
+                    hdul[0].header['HIERARCH ESO INS DRS SLIT'] = hdul[0].header['HIERARCH ESO INS OPTI3 NAME']
             if(tech == "LSS,N"):
                 hdul[0].header['HIERARCH ESO INS MODE'] = "SPEC_N_LOW"
-                #hdul[0].header['HIERARCH ESO INS OPTI12 NAME'] = filt
-                hdul[0].header['HIERARCH ESO INS DRS SLIT'] = "C-38_1"
+                if 'HIERARCH ESO INS OPTI3 NAME' in hdul[0].header:
+                    hdul[0].header['HIERARCH ESO INS DRS SLIT'] = hdul[0].header['HIERARCH ESO INS OPTI3 NAME']
             
             #IMAGING
             if(tech == "IMAGE,LM"):

--- a/Simulations/python/setupSimulations.py
+++ b/Simulations/python/setupSimulations.py
@@ -338,70 +338,86 @@ class setupSimulations():
         # cycle through all the recipes
         for name, recipe in allrcps.items():
 
-            # force dit to be a float
-            recipe["properties"]["dit"] = float(recipe["properties"]["dit"])
-            
-            # get the mode and the prefix for the title
-            print(recipe)
-            mode = recipe["mode"]
-            prefix = recipe["do.catg"]
-            nObs = recipe["properties"]["nObs"]
-            self.tplExpno = 0
-            
-            props = recipe["properties"]
+            # expand any list-valued properties (e.g. filter_name, dit, ndit, ndfilter_name)
+            expanded = [key for key in sd.expandables
+                        if isinstance(recipe["properties"].get(key), list)]
+            combos = list(product(*[recipe["properties"][key] for key in expanded]))
+            if not combos:
+                combos = [()]
 
-            # Apply global slit_name default if not set per-recipe
-            if 'slit_name' not in props and 'slit_name' in self.params:
-                props['slit_name'] = self.params['slit_name']
+            for combo in combos:
+                recipe = copy.deepcopy(recipe)
+                combodict = dict(zip(expanded, combo))
+                recipe["properties"].update(combodict)
 
-            if 'pupil_transmission' not in props and 'pupil_transmission' in self.params:
-                props['pupil_transmission'] = self.params['pupil_transmission']
-            
-            if 'detector_readout_mode' not in props and 'detector_readout_mode' in self.params:
-                props['detector_readout_mode'] = self.params['detector_readout_mode']
+                # force dit to be a float
+                recipe["properties"]["dit"] = float(recipe["properties"]["dit"])
 
-            recipe["properties"]["tplstart"] = self.tplStart
+                # get the mode and the prefix for the title
+                print(recipe)
+                mode = recipe["mode"]
+                prefix = recipe["do.catg"]
+                nObs = recipe["properties"]["nObs"]
+                self.tplExpno = 0
 
-            # for nObs exposures of each set of parameters
-            # this loop mostly calculates the time variables for each
-            # observation, and saves the arguments for the simulation in
-            # a list. The actually calling occurs afterwards, for parallelization
-            
-            for _ in range(nObs):        
+                props = recipe["properties"]
 
-                # set the time related keywords and increment the observing time.
-                # note that tDelt = 0 on the first iteration
+                # Apply slit_name: YAML 'slit' key takes priority, then 'slit_name',
+                # then fall back to the global param default
+                if 'slit_name' not in props:
+                    if 'slit' in props:
+                        props['slit_name'] = props['slit']
+                    elif 'slit_name' in self.params:
+                        props['slit_name'] = self.params['slit_name']
 
-                recipe = self.increment(recipe)
+                if 'pupil_transmission' not in props and 'pupil_transmission' in self.params:
+                    props['pupil_transmission'] = self.params['pupil_transmission']
 
-                self.allFileNames.append(self.fname)
-                self.allmjd.append(self.tObs.mjd)
+                if 'detector_readout_mode' not in props and 'detector_readout_mode' in self.params:
+                    props['detector_readout_mode'] = self.params['detector_readout_mode']
 
-                # set WCU to None if this isn't WCU data
-                if("wcu" not in recipe.keys()):
-                   recipe["wcu"] = None
+                recipe["properties"]["tplstart"] = self.tplStart
 
-                # add the arguments to the list
-                allArgs.append((self.fname,recipe,self.params["small"]))
+                # for nObs exposures of each set of parameters
+                # this loop mostly calculates the time variables for each
+                # observation, and saves the arguments for the simulation in
+                # a list. The actually calling occurs afterwards, for parallelization
 
-                # if the observation is WCU, add a WCU frame to the image, as WCU darks are part of the
-                # same template \TODO set to > 1 if desired
-            
-                if(recipe["wcu"] is not None):
-                    recipeDark = self.copyRecipe("wcuOff",recipe['properties']['tech'])
-                    if(recipeDark is not None):
-                        recipeDark["properties"]["tplstart"] = self.tplStart
-                        recipeDark["properties"]["tplname"] = recipe["properties"]["tplname"]
-                        recipeDark["properties"]["dit"] = recipe["properties"]["dit"] 
-                        recipeDark["properties"]["ndit"] = recipe["properties"]["ndit"] 
-                        recipeDark["properties"]["ndfilter_name"] = recipe["properties"]["ndfilter_name"] 
-                        recipeDark["properties"]["filter_name"] = recipe["properties"]["filter_name"] 
-                        recipeDark = self.increment(recipeDark)
-                        
-                        self.allFileNames.append(self.fname)
-                        self.allmjd.append(self.tObs.mjd)
-                        
-                        allArgs.append((self.fname, recipeDark, self.params["small"]))
+                for _ in range(nObs):
+
+                    # set the time related keywords and increment the observing time.
+                    # note that tDelt = 0 on the first iteration
+
+                    recipe = self.increment(recipe)
+
+                    self.allFileNames.append(self.fname)
+                    self.allmjd.append(self.tObs.mjd)
+
+                    # set WCU to None if this isn't WCU data
+                    if("wcu" not in recipe.keys()):
+                        recipe["wcu"] = None
+
+                    # add the arguments to the list
+                    allArgs.append((self.fname,recipe,self.params["small"]))
+
+                    # if the observation is WCU, add a WCU frame to the image, as WCU darks are part of the
+                    # same template \TODO set to > 1 if desired
+
+                    if(recipe["wcu"] is not None):
+                        recipeDark = self.copyRecipe("wcuOff",recipe['properties']['tech'])
+                        if(recipeDark is not None):
+                            recipeDark["properties"]["tplstart"] = self.tplStart
+                            recipeDark["properties"]["tplname"] = recipe["properties"]["tplname"]
+                            recipeDark["properties"]["dit"] = recipe["properties"]["dit"]
+                            recipeDark["properties"]["ndit"] = recipe["properties"]["ndit"]
+                            recipeDark["properties"]["ndfilter_name"] = recipe["properties"]["ndfilter_name"]
+                            recipeDark["properties"]["filter_name"] = recipe["properties"]["filter_name"]
+                            recipeDark = self.increment(recipeDark)
+
+                            self.allFileNames.append(self.fname)
+                            self.allmjd.append(self.tObs.mjd)
+
+                            allArgs.append((self.fname, recipeDark, self.params["small"]))
 
         # calculate the observation date for the next observation, for
         # stringing a sequence of templates together
@@ -441,14 +457,21 @@ class setupSimulations():
         # assemble a list of the dark / skyflat / lampflat recipe dicionaries
 
         for name, recipe in self.allrcps.items():
-            props = recipe["properties"]
-                
-            if(props["type"] in wcuModes):
-                pass
-             
-            else:
-                darkParms.append((props['dit'],props['ndit'],props['tech']))
-            flatParms.append((props['filter_name'],props['ndfilter_name'],props['tech']))
+            expanded = [key for key in sd.expandables
+                        if isinstance(recipe["properties"].get(key), list)]
+            combos = list(product(*[recipe["properties"][key] for key in expanded]))
+            if not combos:
+                combos = [()]
+
+            for combo in combos:
+                props = recipe["properties"] | dict(zip(expanded, combo))
+
+                if(props["type"] in wcuModes):
+                    pass
+
+                else:
+                    darkParms.append((props['dit'],props['ndit'],props['tech']))
+                flatParms.append((props['filter_name'],props.get('ndfilter_name','open'),props['tech']))
 
             
                              

--- a/Simulations/python/setupSimulations.py
+++ b/Simulations/python/setupSimulations.py
@@ -354,6 +354,12 @@ class setupSimulations():
             if 'slit_name' not in props and 'slit_name' in self.params:
                 props['slit_name'] = self.params['slit_name']
 
+            if 'pupil_transmission' not in props and 'pupil_transmission' in self.params:
+                props['pupil_transmission'] = self.params['pupil_transmission']
+            
+            if 'detector_readout_mode' not in props and 'detector_readout_mode' in self.params:
+                props['detector_readout_mode'] = self.params['detector_readout_mode']
+
             recipe["properties"]["tplstart"] = self.tplStart
 
             # for nObs exposures of each set of parameters
@@ -459,12 +465,12 @@ class setupSimulations():
         and DET.DIT and .NDIT are set in ScopeSim
     
         We use the TECH to get INS.MODE
-        Sets the DRS.SLIT to the default value for now (will fix later)\TODO
+        Sets the DRS.SLIT to the default value for now (will fix later)\\TODO
         Sets INS.OPTI*.NAME to the filter, slit as indicated by the TECH, FILTER and SLIT keyword
     
         For HCI / Coronagraph modes, we set the TECH keyword to a non valid value in Scopesim, 
         and use that to set the DRS.MASK, correct DPR.TECH, and INS.OPTI*.NAME values. This is kludgy,
-        and will be fixed later. \TODO
+        and will be fixed later. \\TODO
     
         We check the TYPE keyword for LASER Sources. 
     
@@ -511,13 +517,10 @@ class setupSimulations():
             
             if(tech == "LSS,LM"):
                 hdul[0].header['HIERARCH ESO INS MODE'] = "SPEC_LM"
-                if 'HIERARCH ESO INS OPTI3 NAME' in hdul[0].header:
-                    hdul[0].header['HIERARCH ESO INS DRS SLIT'] = hdul[0].header['HIERARCH ESO INS OPTI3 NAME']
+
             if(tech == "LSS,N"):
                 hdul[0].header['HIERARCH ESO INS MODE'] = "SPEC_N_LOW"
-                if 'HIERARCH ESO INS OPTI3 NAME' in hdul[0].header:
-                    hdul[0].header['HIERARCH ESO INS DRS SLIT'] = hdul[0].header['HIERARCH ESO INS OPTI3 NAME']
-            
+     
             #IMAGING
             if(tech == "IMAGE,LM"):
                 hdul[0].header['HIERARCH ESO INS MODE'] = "IMG_LM"

--- a/Simulations/python/simulationDefinitions.py
+++ b/Simulations/python/simulationDefinitions.py
@@ -41,6 +41,7 @@ hciFilters = ["HCI_M","HCI_L_short","HCI_L_long","open","closed"]
 
 topKey = ["do.catg","mode","properties"]
 propKey = ["dit","ndit","filter_name","catg","tech","type","nObs"]
+expandables = ["filter_name","dit","ndit","ndfilter_name"]
 
 
 # some templates for calibration dictionaries. DIT/NDIT/obsdate need to be added


### PR DESCRIPTION
Allow overriding the spectroscopic slit via a slit_name parameter at both the global (params) and per-recipe (YAML) level. The parameter flows through to cmd["!OBS.slit"] in ScopeSim before OpticalTrain creation. The updateHeaders() slit handling now reads the actual slit from the FITS header (HIERARCH ESO INS OPTI3 NAME) instead of being hardcoded to C-38_1.

Caveat - not sure if this is the right way to go about it, but it's what Shannon and I found that works now (without fully understanding the code base)