### PR TITLE
adding ./ESO/ to paths so runESO.sh works again.

### DIFF
--- a/simulationBlocks/calib.py
+++ b/simulationBlocks/calib.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     params['nCores'] = nCores
     params['testRun'] = False
 
-    yamls = ["chophomeLM.yaml","pupilLM.yaml","pupilN.yaml","slitlossLSSLM.yaml","slitlossLSSN.yaml"]
+    yamls = ["./ESO/chophomeLM.yaml","./ESO/pupilLM.yaml","./ESO/pupilN.yaml","./ESO/slitlossLSSLM.yaml","./ESO/slitlossLSSN.yaml"]
 
     yamlFiles = []
     for y in yamls:

--- a/simulationBlocks/hciAppLm.py
+++ b/simulationBlocks/hciAppLm.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
         params['nCores'] = nCores
         params['testRun'] = False
         
-        yamls = ["offAxisLM.yaml","hciAppLM.yaml","distortionLM.yaml","detlinLM.yaml"]
+        yamls = ["./ESO/offAxisLM.yaml","./ESO/hciAppLM.yaml","./ESO/distortionLM.yaml","./ESO/detlinLM.yaml"]
 
         yamlFiles = []
         for y in yamls:

--- a/simulationBlocks/hciRavcIfu.py
+++ b/simulationBlocks/hciRavcIfu.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
         params['nCores'] = nCores
         params['testRun'] = False
         
-        yamls = ["hciRavcIfu.yaml","distortionIFU.yaml","detlinIFU.yaml","distortionIFU.yaml","rsrfIFU.yaml","rsrfPinhIFU.yaml","wavecalIFU.yaml","offAxisLM.yaml"]
+        yamls = ["./ESO/hciRavcIfu.yaml","./ESO/distortionIFU.yaml","./ESO/detlinIFU.yaml","./ESO/distortionIFU.yaml","./ESO/rsrfIFU.yaml","./ESO/rsrfPinhIFU.yaml","./ESO/wavecalIFU.yaml","./ESO/offAxisLM.yaml"]
         
         yamlFiles = []
         for y in yamls:

--- a/simulationBlocks/ifu.py
+++ b/simulationBlocks/ifu.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     params['nCores'] = nCores
     params['testRun'] = False
 
-    yamls = ["wavecalIFU.yaml","scienceIFU.yaml","stdIFU.yaml","detlinIFU.yaml","distortionIFU.yaml","rsrfIFU.yaml","rsrfPinhIFU.yaml"]
+    yamls = ["./ESO/wavecalIFU.yaml","./ESO/scienceIFU.yaml","./ESO/stdIFU.yaml","./ESO/detlinIFU.yaml","./ESO/distortionIFU.yaml","./ESO/rsrfIFU.yaml","./ESO/rsrfPinhIFU.yaml"]
 
 
     yamlFiles = []

--- a/simulationBlocks/imgLM.py
+++ b/simulationBlocks/imgLM.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
         params['nCores'] = nCores
         params['testRun'] = False
         
-        yamls = ["scienceLM.yaml","stdLM.yaml","distortionLM.yaml","detlinLM.yaml"]
+        yamls = ["./ESO/scienceLM.yaml","./ESO/stdLM.yaml","./ESO/distortionLM.yaml","./ESO/detlinLM.yaml"]
         
 
         yamlFiles = []

--- a/simulationBlocks/imgLM_t.py
+++ b/simulationBlocks/imgLM_t.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
 	params['nCores'] = 8
 	params['testRun'] = False
 	
-	yamls = ["scienceLM.yaml","stdLM.yaml","distortionLM.yaml","detlinLM.yaml"]
+	yamls = ["./ESO/scienceLM.yaml","./ESO/stdLM.yaml","./ESO/distortionLM.yaml","./ESO/detlinLM.yaml"]
 	
 	rs.runSimulationBlock(yamlFiles,params)
 

--- a/simulationBlocks/imgN.py
+++ b/simulationBlocks/imgN.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
         params['nCores'] = nCores
         params['testRun'] = False
         
-        yamls = ["scienceN.yaml","stdN.yaml","distortionN.yaml","detlinN.yaml"]
+        yamls = ["./ESO/scienceN.yaml","./ESO/stdN.yaml","./ESO/distortionN.yaml","./ESO/detlinN.yaml"]
 
 
         yamlFiles = []

--- a/simulationBlocks/lssLM.py
+++ b/simulationBlocks/lssLM.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     params['nCores'] = nCores
     params['testRun'] = False
 
-    yamls = ["scienceLSSLM.yaml","stdLSSLM.yaml","detlinLM.yaml","distortionLM.yaml","rsrfLSSLM.yaml","rsrfPinhLSSLM.yaml","wavecalLSSLM.yaml","slitlossLSSLM.yaml"]
+    yamls = ["./ESO/scienceLSSLM.yaml","./ESO/stdLSSLM.yaml","./ESO/detlinLM.yaml","./ESO/distortionLM.yaml","./ESO/rsrfLSSLM.yaml","./ESO/rsrfPinhLSSLM.yaml","./ESO/wavecalLSSLM.yaml","./ESO/slitlossLSSLM.yaml"]
 
 
     yamlFiles = []

--- a/simulationBlocks/lssN.py
+++ b/simulationBlocks/lssN.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     params['nCores'] = nCores
     params['testRun'] = False
 
-    yamls = ["scienceLSSN.yaml","stdLSSN.yaml","detlinN.yaml","distortionN.yaml","rsrfLSSN.yaml","rsrfPinhLSSN.yaml","wavecalLSSN.yaml","slitlossLSSN.yaml"]
+    yamls = ["./ESO/scienceLSSN.yaml","./ESO/stdLSSN.yaml","./ESO/detlinN.yaml","./ESO/distortionN.yaml","./ESO/rsrfLSSN.yaml","./ESO/rsrfPinhLSSN.yaml","./ESO/wavecalLSSN.yaml","./ESO/slitlossLSSN.yaml"]
 
     yamlFiles = []
     for y in yamls:


### PR DESCRIPTION
Because the YAMLs were moved one folder deeper runESO.sh didn't work anymore because it was looking for the files in the root YAML folder.