### PR TITLE
Added nd_filter_name explicitly where missing.

### DIFF
--- a/YAML/ESO/calib.yaml
+++ b/YAML/ESO/calib.yaml
@@ -16,6 +16,7 @@ LM_SLITLOSSES_RAW1:
     dit: 0.25
     ndit: 1
     filter_name: "L_spec"
+    nd_filter_name: "open"
     catg: "CALIB"
     tech: "LSS,LM"
     type: "SLITLOSS"
@@ -37,6 +38,7 @@ N_LSS_SLITLOSSES_RAW1:
     dit: 0.25
     ndit: 1
     filter_name: "N_spec"
+    nd_filter_name: "open"
     catg: "CALIB"
     tech: "LSS,N"
     type: "SLITLOSS"
@@ -61,6 +63,7 @@ LM_CHOPHOME_RAW:
     dit: 10.
     ndit: 1
     filter_name: "open"
+    nd_filter_name: "open"
     catg: "CALIB"
     tech: "IMAGE,LM"
     type: "CHOPHOME"
@@ -81,6 +84,7 @@ LM_PUPIL_RAW:
     dit: 10.
     ndit: 1
     filter_name: "open"
+    nd_filter_name: "open"
     catg: "TECHNICAL"
     tech: "PUP,LM"
     type: "PUPIL"
@@ -101,6 +105,7 @@ N_PUPIL_RAW:
     dit: 10.
     ndit: 1
     filter_name: "open"
+    nd_filter_name: "open"
     catg: "TECHNICAL"
     tech: "PUP,N"
     type: "PUPIL"

--- a/YAML/ESO/ifu-rsrf.yaml
+++ b/YAML/ESO/ifu-rsrf.yaml
@@ -57,31 +57,31 @@ IFU_RSRF_RAW2:
     yshift: 0
 
 
-## Explicit WCU_OFF frame
-IFU_WCU_OFF1:
-  do.catg: IFU_WCU_OFF_RAW
-  mode: "wcu_lms"
-  source: 
-    name: empty_sky
-    kwargs: {}
-  properties:
-    dit: 10
-    ndit: 20
-    wavelen: 3.555
-    filter_name: "open"
-    nd_filter_name: "open"
-    catg: "CALIB"
-    tech: "IFU"
-    type: "RSRF"
-    tplname: "METIS_ifu_cal_rsrf"
-    nObs: 1
-  wcu:
-    current_lamp: "bb"
-    current_fpmask: "grid_lm"
-    bb_aperture: 0.0
-    bb_temp: 800
-    is_temp: 300
-    wcu_temp: 300
+# ## Explicit WCU_OFF frame
+# IFU_WCU_OFF1:
+#   do.catg: IFU_WCU_OFF_RAW
+#   mode: "wcu_lms"
+#   source: 
+#     name: empty_sky
+#     kwargs: {}
+#   properties:
+#     dit: 10
+#     ndit: 20
+#     wavelen: 3.555
+#     filter_name: "open"
+#     nd_filter_name: "open"
+#     catg: "CALIB"
+#     tech: "IFU"
+#     type: "RSRF"
+#     tplname: "METIS_ifu_cal_rsrf"
+#     nObs: 1
+#   wcu:
+#     current_lamp: "bb"
+#     current_fpmask: "grid_lm"
+#     bb_aperture: 0.0
+#     bb_temp: 800
+#     is_temp: 300
+#     wcu_temp: 300
 
 ## SKY image for waveval
 IFU_SKY_RAW1:

--- a/YAML/ESO/ifu-rsrf.yaml
+++ b/YAML/ESO/ifu-rsrf.yaml
@@ -57,7 +57,7 @@ IFU_RSRF_RAW2:
     yshift: 0
 
 
-## WCU_OFF frames
+## Explicit WCU_OFF frame
 IFU_WCU_OFF1:
   do.catg: IFU_WCU_OFF_RAW
   mode: "wcu_lms"
@@ -77,9 +77,9 @@ IFU_WCU_OFF1:
     nObs: 1
   wcu:
     current_lamp: "bb"
-    current_fpmask: "open"
+    current_fpmask: "grid_lm"
     bb_aperture: 0.0
-    bb_temp: 300
+    bb_temp: 800
     is_temp: 300
     wcu_temp: 300
 
@@ -94,6 +94,7 @@ IFU_SKY_RAW1:
     dit: 100
     ndit: 3
     filter_name: "open"
+    nd_filter_name: "open"
     wavelen: "3.555"
     catg: "CALIB"
     tech: "IFU"

--- a/YAML/ESO/ifu.yaml
+++ b/YAML/ESO/ifu.yaml
@@ -58,7 +58,7 @@ IFU_DISTORTION_RAW:
     is_temp: 300
     wcu_temp: 300
     xshift: 0
-    yshirt: 0
+    yshift: 0
 
 
 
@@ -235,31 +235,31 @@ IFU_RSRF_RAW2:
     yshift: 0
 
 
-## WCU_OFF frames
-IFU_WCU_OFF1:
-  do.catg: IFU_WCU_OFF_RAW
-  mode: "wcu_lms"
-  source:
-    name: empty_sky
-    kwargs: {}
-  properties:
-    dit: 10
-    ndit: 20
-    wavelen: 3.555
-    filter_name: "open"
-    nd_filter_name: "open"
-    catg: "CALIB"
-    tech: "IFU"
-    type: "RSRF"
-    tplname: "METIS_ifu_cal_rsrf"
-    nObs: 1
-  wcu:
-    current_lamp: "bb"
-    current_fpmask: "open"
-    bb_aperture: 0.0
-    bb_temp: 300
-    is_temp: 300
-    wcu_temp: 300
+# ## WCU_OFF frames - auto-generated
+# IFU_WCU_OFF1:
+#   do.catg: IFU_WCU_OFF_RAW
+#   mode: "wcu_lms"
+#   source:
+#     name: empty_sky
+#     kwargs: {}
+#   properties:
+#     dit: 10
+#     ndit: 20
+#     wavelen: 3.555
+#     filter_name: "open"
+#     nd_filter_name: "open"
+#     catg: "CALIB"
+#     tech: "IFU"
+#     type: "RSRF"
+#     tplname: "METIS_ifu_cal_rsrf"
+#     nObs: 1
+#   wcu:
+#     current_lamp: "bb"
+#     current_fpmask: "open"
+#     bb_aperture: 0.0
+#     bb_temp: 300
+#     is_temp: 300
+#     wcu_temp: 300
 
 ## SKY image for waveval
 IFU_SKY_RAW1:

--- a/YAML/ESO/ifu.yaml
+++ b/YAML/ESO/ifu.yaml
@@ -15,6 +15,7 @@ DETLIN_IFU_RAW:
     ndit: 1
     wavelen: 3.555
     filter_name: "open"
+    nd_filter_name: "open"
     catg: "CALIB"
     tech: "IFU"
     type: "DETLIN"
@@ -102,6 +103,7 @@ IFU_SCI_RAW:
     ndit: 1
     wavelen: 3.555
     filter_name: "open"
+    nd_filter_name: "open"
     catg: "SCIENCE"
     tech: "IFU"
     type: "OBJECT"
@@ -119,6 +121,7 @@ IFU_SCI_SKY_RAW:
     ndit: 1
     wavelen: 3.555
     filter_name: "open"
+    nd_filter_name: "open"
     catg: "CALIB"
     tech: "IFU"
     type: "SKY"
@@ -141,6 +144,7 @@ IFU_STD_RAW:
     ndit: 3
     wavelen: 3.555
     filter_name: "open"
+    nd_filter_name: "open"
     wavelen: "3.555"
     catg: "CALIB"
     tech: "IFU"
@@ -165,6 +169,7 @@ IFU_STD_SKY_RAW:
     ndit: 3
     wavelen: 3.555
     filter_name: "open"
+    nd_filter_name: "open"
     catg: "CALIB"
     tech: "IFU"
     type: "SKY"
@@ -268,6 +273,7 @@ IFU_SKY_RAW1:
     ndit: 3
     wavelen: 3.555
     filter_name: "open"
+    nd_filter_name: "open"
     catg: "CALIB"
     tech: "IFU"
     type: "SKY"


### PR DESCRIPTION
This parameter was still missing in some YAMLs, especially the calib.yaml that is widely used?