### PR TITLE
Karr/fixrunner

### DIFF
--- a/.github/workflows/run_recipes.yml
+++ b/.github/workflows/run_recipes.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run recipes
         run: |
           export MSIM_YAML_DIR="YAML/Tests"
-          export MSIM_NCORES=1
+          export MSIM_NCORES=6
           export DEFAULT_IRDB_LOCATION="irdb"
           export MSIM_OUTDIR="."
   

--- a/.github/workflows/run_recipes.yml
+++ b/.github/workflows/run_recipes.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run recipes
         run: |
           export MSIM_YAML_DIR="YAML/Tests"
-          export MSIM_NCORES=6
+          export MSIM_NCORES=1
           export DEFAULT_IRDB_LOCATION="irdb"
           export MSIM_OUTDIR="."
   

--- a/.github/workflows/run_recipes.yml
+++ b/.github/workflows/run_recipes.yml
@@ -32,8 +32,7 @@ jobs:
         run: |
           export MSIM_YAML_DIR="YAML/Tests"
           export MSIM_NCORES=6
-          export DEFAULT_IRDB_LOCATION="inst_pkgs"
+          export DEFAULT_IRDB_LOCATION="irdb"
           export MSIM_OUTDIR="."
   
-          ln -s irdb inst_pkgs # symbolic link to git-cloned irdb copy to ensure latest irdb version (vs released version in download_packages)
           python simulationBlocks/Tests/ci.py --small

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/AstarVienna/METIS_Simulations"
 documentation = "https://scopesim.readthedocs.io/en/latest/"
 requires-python = ">=3.12,<3.15"
 dependencies = [
-    "scopesim >=0.11.3",
+    "scopesim @ git+https://github.com/astarVienna/scopesim",
     "scopesim_templates >=0.8.1"
 ]
 [tool.poetry]


### PR DESCRIPTION
Fix of crash due to incompatible hashes; ScopeSim needs to be current main to match, not the most recent release. 