### PR TITLE
Update to detlin YAML's

### DIFF
--- a/YAML/ESO/detlinIFU.yaml
+++ b/YAML/ESO/detlinIFU.yaml
@@ -14,7 +14,7 @@ DETLIN_IFU_RAW_ON1:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -39,7 +39,7 @@ DETLIN_IFU_RAW_ON2:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -65,7 +65,7 @@ DETLIN_IFU_RAW_ON3:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -90,7 +90,7 @@ DETLIN_IFU_RAW_ON4:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -116,7 +116,7 @@ DETLIN_IFU_RAW_ON5:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -141,7 +141,7 @@ DETLIN_IFU_RAW_ON6:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -167,7 +167,7 @@ DETLIN_IFU_RAW_ON7:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -192,7 +192,7 @@ DETLIN_IFU_RAW_ON8:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -217,7 +217,7 @@ DETLIN_IFU_RAW_ON9:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -242,7 +242,7 @@ DETLIN_IFU_RAW_ON10:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -268,7 +268,7 @@ DETLIN_IFU_RAW_ON11:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -293,7 +293,7 @@ DETLIN_IFU_RAW_ON12:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -319,7 +319,7 @@ DETLIN_IFU_RAW_ON13:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -344,7 +344,7 @@ DETLIN_IFU_RAW_ON14:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -370,7 +370,7 @@ DETLIN_IFU_RAW_ON15:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -395,7 +395,7 @@ DETLIN_IFU_RAW_ON16:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -421,7 +421,7 @@ DETLIN_IFU_RAW_OFF1:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -446,7 +446,7 @@ DETLIN_IFU_RAW_OFF2:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -472,7 +472,7 @@ DETLIN_IFU_RAW_OFF3:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -497,7 +497,7 @@ DETLIN_IFU_RAW_OFF4:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -523,7 +523,7 @@ DETLIN_IFU_RAW_OFF5:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -548,7 +548,7 @@ DETLIN_IFU_RAW_OFF6:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -574,7 +574,7 @@ DETLIN_IFU_RAW_OFF7:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -599,7 +599,7 @@ DETLIN_IFU_RAW_OFF8:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -624,7 +624,7 @@ DETLIN_IFU_RAW_OFF9:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -649,7 +649,7 @@ DETLIN_IFU_RAW_OFF10:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -675,7 +675,7 @@ DETLIN_IFU_RAW_OFF11:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -700,7 +700,7 @@ DETLIN_IFU_RAW_OFF12:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -726,7 +726,7 @@ DETLIN_IFU_RAW_OFF13:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -751,7 +751,7 @@ DETLIN_IFU_RAW_OFF14:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -777,7 +777,7 @@ DETLIN_IFU_RAW_OFF15:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -802,7 +802,7 @@ DETLIN_IFU_RAW_OFF16:
     filter_name: "closed"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "LMS"
+    tech: "IFU"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1

--- a/YAML/ESO/detlinIFU.yaml
+++ b/YAML/ESO/detlinIFU.yaml
@@ -1,20 +1,20 @@
 
 ############ DETLIN WITH DIFFERENT EXPOSURE TIMES ##################
 
-DETLIN_IFU_RAW1:
+DETLIN_IFU_RAW_ON1:
   do.catg: DETLIN_IFU_RAW
   mode: "wcu_lms"
   source:
     name: empty_sky
     kwargs: {}
   properties:
-    dit: 1.
+    dit: 1.5
     ndit: 1
     wavelen: 3.555
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "IFU"
+    tech: "LMS"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -26,7 +26,33 @@ DETLIN_IFU_RAW1:
     is_temp: 300
     wcu_temp: 300
 
-DETLIN_IFU_RAW2:
+DETLIN_IFU_RAW_ON2:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.5
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "open"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+    
+DETLIN_IFU_RAW_ON3:
   do.catg: DETLIN_IFU_RAW
   mode: "wcu_lms"
   source:
@@ -39,7 +65,7 @@ DETLIN_IFU_RAW2:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "IFU"
+    tech: "LMS"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -51,7 +77,33 @@ DETLIN_IFU_RAW2:
     is_temp: 300
     wcu_temp: 300
 
-DETLIN_IFU_RAW3:
+DETLIN_IFU_RAW_ON4:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 2.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "open"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+    
+DETLIN_IFU_RAW_ON5:
   do.catg: DETLIN_IFU_RAW
   mode: "wcu_lms"
   source:
@@ -64,7 +116,7 @@ DETLIN_IFU_RAW3:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "IFU"
+    tech: "LMS"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -76,7 +128,33 @@ DETLIN_IFU_RAW3:
     is_temp: 300
     wcu_temp: 300
 
-DETLIN_IFU_RAW4:
+DETLIN_IFU_RAW_ON6:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 3.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "open"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+    
+DETLIN_IFU_RAW_ON7:
   do.catg: DETLIN_IFU_RAW
   mode: "wcu_lms"
   source:
@@ -89,7 +167,7 @@ DETLIN_IFU_RAW4:
     filter_name: "open"
     nd_filter_name: "open"
     catg: "CALIB"
-    tech: "IFU"
+    tech: "LMS"
     type: "DETLIN"
     tplname: "METIS_ifu_cal_DetLin"
     nObs: 1
@@ -101,3 +179,637 @@ DETLIN_IFU_RAW4:
     is_temp: 300
     wcu_temp: 300
 
+DETLIN_IFU_RAW_ON8:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 4.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "open"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW_ON9:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 6.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "open"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW_ON10:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 6.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "open"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+    
+DETLIN_IFU_RAW_ON11:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 8.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "open"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW_ON12:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 8.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "open"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+    
+DETLIN_IFU_RAW_ON13:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 10.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "open"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW_ON14:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 10.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "open"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+    
+DETLIN_IFU_RAW_ON15:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 16.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "open"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW_ON16:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 16.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "open"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+    
+DETLIN_IFU_RAW_OFF1:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.5
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW_OFF2:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.5
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+    
+DETLIN_IFU_RAW_OFF3:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 2.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW_OFF4:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 2.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+    
+DETLIN_IFU_RAW_OFF5:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 3.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW_OFF6:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 3.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+    
+DETLIN_IFU_RAW_OFF7:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 4.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW_OFF8:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 4.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW_OFF9:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 6.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW_OFF10:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 6.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+    
+DETLIN_IFU_RAW_OFF11:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 8.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW_OFF12:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 8.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+    
+DETLIN_IFU_RAW_OFF13:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 10.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW_OFF14:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 10.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+    
+DETLIN_IFU_RAW_OFF15:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 16.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_IFU_RAW_OFF16:
+  do.catg: DETLIN_IFU_RAW
+  mode: "wcu_lms"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 16.
+    ndit: 1
+    wavelen: 3.555
+    filter_name: "closed"
+    nd_filter_name: "open"
+    catg: "CALIB"
+    tech: "LMS"
+    type: "DETLIN"
+    tplname: "METIS_ifu_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300

--- a/YAML/ESO/detlinLM.yaml
+++ b/YAML/ESO/detlinLM.yaml
@@ -1,6 +1,5 @@
 ############ DETLIN WITH DIFFERENT EXPOSURE TIMES ##################
 
-
 DETLIN_2RG_RAW1:
   do.catg: DETLIN_2RG_RAW
   mode: "wcu_img_lm"
@@ -10,8 +9,8 @@ DETLIN_2RG_RAW1:
   properties:
     dit: 1.
     ndit: 1
-    filter_name: "open"
-    nd_filter_name: "open"
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
     catg: "CALIB"
     tech: "IMAGE,LM"
     type: "DETLIN"
@@ -32,10 +31,10 @@ DETLIN_2RG_RAW2:
     name: empty_sky
     kwargs: {}
   properties:
-    dit: 2.
+    dit: 1.
     ndit: 1
-    filter_name: "open"
-    nd_filter_name: "open"
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
     catg: "CALIB"
     tech: "IMAGE,LM"
     type: "DETLIN"
@@ -56,10 +55,10 @@ DETLIN_2RG_RAW3:
     name: empty_sky
     kwargs: {}
   properties:
-    dit: 3.
+    dit: 2.
     ndit: 1
-    filter_name: "open"
-    nd_filter_name: "open"
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
     catg: "CALIB"
     tech: "IMAGE,LM"
     type: "DETLIN"
@@ -80,10 +79,10 @@ DETLIN_2RG_RAW4:
     name: empty_sky
     kwargs: {}
   properties:
-    dit: 4.
+    dit: 2.
     ndit: 1
-    filter_name: "open"
-    nd_filter_name: "open"
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
     catg: "CALIB"
     tech: "IMAGE,LM"
     type: "DETLIN"
@@ -97,3 +96,674 @@ DETLIN_2RG_RAW4:
     is_temp: 300
     wcu_temp: 300
 
+DETLIN_2RG_RAW5:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 3.
+    ndit: 1
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW6:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 3.
+    ndit: 1
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW7:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 4.
+    ndit: 1
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW8:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 4.
+    ndit: 1
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW9:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.4
+    ndit: 1
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW10:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.4
+    ndit: 1
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW11:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 1
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW12:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 1
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW13:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.1
+    ndit: 1
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW14:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.1
+    ndit: 1
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW15:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 1
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW16:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 1
+    filter_name: "IB_4.05"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW1_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW2_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW3_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 2.
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW4_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 2.
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW5_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 3.
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW6_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 3.
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW7_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 4.
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW8_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 4.
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW9_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.4
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW10_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.4
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW11_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW12_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW13_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.1
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW14_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.1
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW15_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_2RG_RAW16_OFF:
+  do.catg: DETLIN_2RG_RAW
+  mode: "wcu_img_lm"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.05
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD3"
+    catg: "CALIB"
+    tech: "IMAGE,LM"
+    type: "DETLIN"
+    tplname: "METIS_img_lm_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300

--- a/YAML/ESO/detlinN.yaml
+++ b/YAML/ESO/detlinN.yaml
@@ -7,10 +7,10 @@ DETLIN_GEO_RAW1:
     name: empty_sky
     kwargs: {}
   properties:
-    dit: 1.
+    dit: 0.1
     ndit: 1
-    filter_name: "open"
-    nd_filter_name: "open"
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
     catg: "CALIB"
     tech: "IMAGE,N"
     type: "DETLIN"
@@ -31,10 +31,10 @@ DETLIN_GEO_RAW2:
     name: empty_sky
     kwargs: {}
   properties:
-    dit: 2.
+    dit: 0.1
     ndit: 1
-    filter_name: "open"
-    nd_filter_name: "open"
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
     catg: "CALIB"
     tech: "IMAGE,N"
     type: "DETLIN"
@@ -55,10 +55,10 @@ DETLIN_GEO_RAW3:
     name: empty_sky
     kwargs: {}
   properties:
-    dit: 3.
+    dit: 0.2
     ndit: 1
-    filter_name: "open"
-    nd_filter_name: "open"
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
     catg: "CALIB"
     tech: "IMAGE,N"
     type: "DETLIN"
@@ -79,10 +79,682 @@ DETLIN_GEO_RAW4:
     name: empty_sky
     kwargs: {}
   properties:
-    dit: 4.
+    dit: 0.2
     ndit: 1
-    filter_name: "open"
-    nd_filter_name: "open"
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW5:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.5
+    ndit: 1
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW6:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.5
+    ndit: 1
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW7:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.0
+    ndit: 1
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW8:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.0
+    ndit: 1
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW9:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.2
+    ndit: 1
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW10:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.2
+    ndit: 1
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW11:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.04
+    ndit: 1
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW12:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.04
+    ndit: 1
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW13:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.02
+    ndit: 1
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW14:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.02
+    ndit: 1
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW15:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.5
+    ndit: 1
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW16:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.5
+    ndit: 1
+    filter_name: "PAH_8.6"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW1_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.1
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW2_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.1
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW3_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW4_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.2
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW5_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.5
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW6_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.5
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW7_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.0
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW8_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.0
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW9_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.2
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW10_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.2
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW11_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.04
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW12_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.04
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW13_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.02
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW14_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 0.02
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW15_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.5
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
+    catg: "CALIB"
+    tech: "IMAGE,N"
+    type: "DETLIN"
+    tplname: "METIS_img_n_cal_DetLin"
+    nObs: 1
+  wcu:
+    current_lamp: "bb"
+    current_fpmask: "open"
+    bb_aperture: 0.5
+    bb_temp: 800
+    is_temp: 300
+    wcu_temp: 300
+
+DETLIN_GEO_RAW16_OFF:
+  do.catg: DETLIN_GEO_RAW
+  mode: "wcu_img_n"
+  source:
+    name: empty_sky
+    kwargs: {}
+  properties:
+    dit: 1.5
+    ndit: 1
+    filter_name: "closed"
+    nd_filter_name: "ND_OD2"
     catg: "CALIB"
     tech: "IMAGE,N"
     type: "DETLIN"


### PR DESCRIPTION
For each subinstrument this creates detlin datasets that are span the linearity range. For each DIT there are 2 frames with flux and 2 darks.

This dataset matches what https://github.com/AstarVienna/METIS_Pipeline/pull/197 expects.