### PR TITLE
Enable simple translation functionality, without the need to run Simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,20 @@ so the same command also works with a YAML file. All other flags from
 `setupSimulations.parseCommandLine` apply (`-o`, `-s`, `-d`, `-q`, `-t`,
 `-f`, `-n`) regardless of input format.
 
+### Inspecting the CSV → YAML mapping
+
+To review what the CSV parser produced without running any simulations,
+combine `--testRun` with `--writeYaml`:
+
+```
+python -m metis_simulations.runSimulationBlock -i path/to/test_sequence.csv -o out/ -t -w
+```
+
+This writes a `.yaml` file next to the input CSV containing the parsed
+recipes and exits before any ScopeSim call. `-w` on its own also writes
+the YAML but then continues into the normal simulation run; `-w` is
+ignored for YAML input.
+
 ## Programmatic usage
 
 The CSV parser can also be used directly:

--- a/metis_simulations/runSimulationBlock.py
+++ b/metis_simulations/runSimulationBlock.py
@@ -28,8 +28,14 @@ def runSimulationBlock(yamlFiles, params, args):
         simulationSet.params['nCores'] = int(simulationSet.params['nCores'])
 
         # load the YAML file
-        
+
         simulationSet.loadYAML()
+
+        # if both --testRun and --writeYaml are set, the user only wants the
+        # parsed-recipes YAML next to each CSV input — skip the rest of the
+        # per-file pipeline (simulations, header updates, calib bookkeeping)
+        if simulationSet.params.get('testRun') and simulationSet.params.get('writeYaml'):
+            continue
 
         # get the start date
         simulationSet.getStartDate()
@@ -49,6 +55,12 @@ def runSimulationBlock(yamlFiles, params, args):
             simulationSet.calculateCalibs()
             allDarks = allDarks + simulationSet.darkParms
             allFlats = allFlats + simulationSet.flatParms
+
+    # if --testRun + --writeYaml were set, every input was short-circuited
+    # above; nothing was simulated and self.tObs was never initialised, so the
+    # calib bookkeeping below would crash. Done.
+    if params.get('testRun') and params.get('writeYaml'):
+        return
 
     # now do all the calibrations
 
@@ -80,7 +92,8 @@ if __name__ == "__main__":
         sys.exit("error: -o/--outputDir is required")
 
     for key, default in (('small', False), ('doStatic', False),
-                         ('doCalib', 0), ('testRun', False), ('nCores', 1)):
+                         ('doCalib', 0), ('testRun', False), ('nCores', 1),
+                         ('writeYaml', False)):
         if params[key] is None:
             params[key] = default
 

--- a/metis_simulations/runSimulationBlock.py
+++ b/metis_simulations/runSimulationBlock.py
@@ -31,9 +31,6 @@ def runSimulationBlock(yamlFiles, params, args):
 
         simulationSet.loadYAML()
 
-        # if both --testRun and --writeYaml are set, the user only wants the
-        # parsed-recipes YAML next to each CSV input — skip the rest of the
-        # per-file pipeline (simulations, header updates, calib bookkeeping)
         if simulationSet.params.get('testRun') and simulationSet.params.get('writeYaml'):
             continue
 
@@ -56,9 +53,6 @@ def runSimulationBlock(yamlFiles, params, args):
             allDarks = allDarks + simulationSet.darkParms
             allFlats = allFlats + simulationSet.flatParms
 
-    # if --testRun + --writeYaml were set, every input was short-circuited
-    # above; nothing was simulated and self.tObs was never initialised, so the
-    # calib bookkeeping below would crash. Done.
     if params.get('testRun') and params.get('writeYaml'):
         return
 

--- a/metis_simulations/setupSimulations.py
+++ b/metis_simulations/setupSimulations.py
@@ -96,6 +96,9 @@ class setupSimulations():
         parser.add_argument('-n', '--nCores', type=int, default=None,
                             help='number of cores for parallel processing')
 
+        parser.add_argument('-w', '--writeYaml', action="store_true", default=None,
+                            help='write a YAML file with the parsed recipes next to the input CSV (only meaningful with .csv input). Combine with --testRun to skip simulation entirely.')
+
         inArgs = parser.parse_args(args)
         params = vars(inArgs)
 
@@ -126,7 +129,7 @@ class setupSimulations():
                 self.allrcps = yaml.safe_load(file)
             print(f"Recipes loaded from {input_path}")
         elif ext == '.csv':
-            self.allrcps = loadCSV(input_path)
+            self.allrcps = loadCSV(input_path, write_yaml=bool(self.params.get('writeYaml')))
         else:
             raise ValueError(f"Unsupported input format: {ext}. Use .yaml, .yml, or .csv")
 


### PR DESCRIPTION
This PR aims to implement the functionality of using METIS Simulations as a quick parser/translator between the CSV AIT test files and the otherwise used yaml input.

This was technically possible already, however only by calling `csvParser.loadCSV(..., write_yaml=True)` from a Python script, not from the CLI.

When `--writeYaml` is combined with `--testRun`, `runSimulationBlock` writes the parsed YAML next to each input CSV and exits cleanly before any Simulation call.

